### PR TITLE
Updates to fix issue when calling the changeRequests list endpoint

### DIFF
--- a/splitapiclient/microclients/change_request_microclient.py
+++ b/splitapiclient/microclients/change_request_microclient.py
@@ -19,7 +19,7 @@ class ChangeRequestMicroClient:
             'query_string': [],
             'response': True,
         },     
-        'list_initial_no_environment': {
+        'list_initial_all_environments': {
             'method': 'GET',
             'url_template': 'changeRequests?limit=100',
             'headers': [{
@@ -31,6 +31,17 @@ class ChangeRequestMicroClient:
             'response': True,
         },
         'list_next': {
+            'method': 'GET',
+            'url_template': 'changeRequests?limit=100&after={after}',
+            'headers': [{
+                'name': 'Authorization',
+                'template': 'Bearer {value}',
+                'required': True,
+            }],
+            'query_string': [],
+            'response': True,
+        },
+        'list_next_all_environments': {
             'method': 'GET',
             'url_template': 'changeRequests?limit=100&environmentId={environmentId}&after={after}',
             'headers': [{
@@ -88,8 +99,13 @@ class ChangeRequestMicroClient:
                 )
             elif afterMarker==0 and environment_id==None:
                 response = self._http_client.make_request(
-                    self._endpoint['list_initial_no_environment'],
+                    self._endpoint['list_initial_all_environments'],
                 ) 
+            elif environment_id==None:
+                response = self._http_client.make_request(
+                    self._endpoint['list_next_all_environments'],
+                    after = afterMarker
+                )
             else:
                 response = self._http_client.make_request(
                     self._endpoint['list_next'],

--- a/splitapiclient/microclients/change_request_microclient.py
+++ b/splitapiclient/microclients/change_request_microclient.py
@@ -32,7 +32,7 @@ class ChangeRequestMicroClient:
         },
         'list_next': {
             'method': 'GET',
-            'url_template': 'changeRequests?limit=100&after={after}',
+            'url_template': 'changeRequests?limit=100&environmentId={environmentId}&after={after}',
             'headers': [{
                 'name': 'Authorization',
                 'template': 'Bearer {value}',
@@ -43,7 +43,7 @@ class ChangeRequestMicroClient:
         },
         'list_next_all_environments': {
             'method': 'GET',
-            'url_template': 'changeRequests?limit=100&environmentId={environmentId}&after={after}',
+            'url_template': 'changeRequests?limit=100&after={after}',
             'headers': [{
                 'name': 'Authorization',
                 'template': 'Bearer {value}',
@@ -109,7 +109,8 @@ class ChangeRequestMicroClient:
             else:
                 response = self._http_client.make_request(
                     self._endpoint['list_next'],
-                    after = afterMarker
+                    after = afterMarker,
+                    environmentId = environment_id
                 )
             for item in response['data']:
                 final_list.append(as_dict(item))

--- a/splitapiclient/microclients/change_request_microclient.py
+++ b/splitapiclient/microclients/change_request_microclient.py
@@ -10,7 +10,7 @@ class ChangeRequestMicroClient:
     _endpoint = {
         'list_initial': {
             'method': 'GET',
-            'url_template': 'changeRequests?limit=100',
+            'url_template': 'changeRequests?limit=100&environmentId={environmentId}',
             'headers': [{
                 'name': 'Authorization',
                 'template': 'Bearer {value}',
@@ -21,7 +21,7 @@ class ChangeRequestMicroClient:
         },
         'list_next': {
             'method': 'GET',
-            'url_template': 'changeRequests?limit=100&after={after}',
+            'url_template': 'changeRequests?limit=100&environmentId={environmentId}&after={after}',
             'headers': [{
                 'name': 'Authorization',
                 'template': 'Bearer {value}',
@@ -60,7 +60,7 @@ class ChangeRequestMicroClient:
         '''
         self._http_client = http_client
 
-    def list(self):
+    def list(self, environment_id):
         '''
         Returns a list of change request objects.
 
@@ -72,7 +72,8 @@ class ChangeRequestMicroClient:
         while True:
             if afterMarker==0:
                 response = self._http_client.make_request(
-                    self._endpoint['list_initial']
+                    self._endpoint['list_initial'],
+                    environmentId = environment_id
                 )
             else:
                 response = self._http_client.make_request(
@@ -86,7 +87,7 @@ class ChangeRequestMicroClient:
             else:
                 afterMarker = response['nextMarker']
                 continue
-        return [ChangeRequest(item, self._http_client) for item in final_list]
+        return [ChangeRequest(item,  self._http_client) for item in final_list]
 
     def find(self, split_name=None, segment_name=None, environment_id=None):
         '''
@@ -96,11 +97,9 @@ class ChangeRequestMicroClient:
         :rtype: list(ChangeRequest)
         '''
         final_list = []
-        for item in self.list():
+        for item in self.list(environment_id):
             if item._split != None:
                 if item._split['name'] == split_name:
-                    final_list.append(item)
-                if item._split['environment']['id'] == environment_id:
                     final_list.append(item)
             if item._segment != None:
                 if item._segment['name'] == segment_name:

--- a/splitapiclient/microclients/change_request_microclient.py
+++ b/splitapiclient/microclients/change_request_microclient.py
@@ -18,6 +18,17 @@ class ChangeRequestMicroClient:
             }],
             'query_string': [],
             'response': True,
+        },     
+        'list_initial_no_environment': {
+            'method': 'GET',
+            'url_template': 'changeRequests?limit=100',
+            'headers': [{
+                'name': 'Authorization',
+                'template': 'Bearer {value}',
+                'required': True,
+            }],
+            'query_string': [],
+            'response': True,
         },
         'list_next': {
             'method': 'GET',
@@ -70,11 +81,15 @@ class ChangeRequestMicroClient:
         final_list = []
         afterMarker = 0
         while True:
-            if afterMarker==0:
+            if afterMarker==0 and environment_id!=None:
                 response = self._http_client.make_request(
                     self._endpoint['list_initial'],
                     environmentId = environment_id
                 )
+            elif afterMarker==0 and environment_id==None:
+                response = self._http_client.make_request(
+                    self._endpoint['list_initial_no_environment'],
+                ) 
             else:
                 response = self._http_client.make_request(
                     self._endpoint['list_next'],


### PR DESCRIPTION
If using an Admin API key scoped to a single environment you must pass in the environment id when using the admin api. The changes I made here should allow that while also continuing to allow the existing behavior for admin api keys scoped to all environments.