### PR TITLE
Single API request to get split definition by name

### DIFF
--- a/splitapiclient/microclients/split_definition_microclient.py
+++ b/splitapiclient/microclients/split_definition_microclient.py
@@ -1,5 +1,5 @@
 from splitapiclient.resources import SplitDefinition
-from splitapiclient.util.exceptions import HTTPResponseError, \
+from splitapiclient.util.exceptions import HTTPNotFoundError, HTTPResponseError, \
     UnknownApiClientError
 from splitapiclient.util.logger import LOGGER
 from splitapiclient.util.helpers import as_dict
@@ -11,6 +11,17 @@ class SplitDefinitionMicroClient:
         'all_items': {
             'method': 'GET',
             'url_template': 'splits/ws/{workspaceId}/environments/{environmentId}?limit=20&offset={offset}',
+            'headers': [{
+                'name': 'Authorization',
+                'template': 'Bearer {value}',
+                'required': True,
+            }],
+            'query_string': [],
+            'response': True,
+        },
+        'get_definition': {
+            'method': 'GET',
+            'url_template': ('splits/ws/{workspaceId}/{splitName}/environments/{environmentId}'),
             'headers': [{
                 'name': 'Authorization',
                 'template': 'Bearer {value}',
@@ -101,6 +112,26 @@ class SplitDefinitionMicroClient:
         LOGGER.error("Split Name does not exist")
         return None
 
+    def get_definition(self, split_name, environment_id, workspace_id):
+        '''
+        Get a Split definition in a single API request.
+
+        :returns: SplitDefinition object
+        :rtype: SplitDefinition
+        '''
+        try:
+            response = self._http_client.make_request(
+                    self._endpoint['get_definition'],
+                    workspaceId = workspace_id,
+                    environmentId = environment_id,
+                    splitName = split_name
+            )
+            item = as_dict(response)
+            return SplitDefinition(item, environment_id, workspace_id, self._http_client)
+        except HTTPNotFoundError as e:
+            LOGGER.error("Split Name '%s' does not exist", split_name)
+            return None
+        
     def update_definition(self, split_name, environment_id, workspace_id, new_definition):
         '''
         update a split definition

--- a/splitapiclient/tests/microclients/split_definition_microclient_test.py
+++ b/splitapiclient/tests/microclients/split_definition_microclient_test.py
@@ -105,3 +105,50 @@ class TestSplitDefinitionMicroClient:
             }]
         assert object_to_stringified_dict(result[0]) == data[0]
         assert object_to_stringified_dict(result[1]) == data[1]
+        
+    def test_get_definition(self, mocker):
+        '''
+        '''
+        mocker.patch('splitapiclient.http_clients.sync_client.SyncHttpClient.make_request')
+        sc = SyncHttpClient('abc', 'abc')
+        emc = SplitDefinitionMicroClient(sc)
+        data = {
+                'name': 'split1',
+                'environment': Environment(data={'changePermissions': None, 'creationTime': None, 'dataExportPermissions': None, 'environmentType': None, 'workspaceIds': ['ws_id'], 'name':None, 'type': None, 'orgId': None, 'id':None, 'status':None}).to_dict(),
+                'trafficType': {'displayAttributeId': None, 'id': None, 'name': None},
+                'killed': False,
+                'treatments': [],
+                'defaultTreatment': 'off',
+                'baselineTreatment': 'off',
+                'trafficAllocation': 100,
+                'rules': [],
+                'defaultRule': [],
+                'creationTime': None,
+                'lastUpdateTime': None,
+                'lastTrafficReceivedAt': None
+            }
+
+        SyncHttpClient.make_request.return_value = data
+        result = emc.get_definition('split1', 'env_id', 'ws_id')
+        SyncHttpClient.make_request.assert_called_once_with(
+            SplitDefinitionMicroClient._endpoint['get_definition'],
+            workspaceId = 'ws_id',
+            environmentId = 'env_id',
+            splitName = 'split1'
+        )
+        data = {
+                'name': 'split1',
+                'environment': Environment(data={'changePermissions': None, 'creationTime': None, 'dataExportPermissions': None, 'environmentType': None, 'workspaceIds': ['ws_id'], 'name':None, 'type': None, 'orgId': None, 'id':None, 'status':None}).to_dict(),
+                'trafficType': {'displayAttributeId': None, 'id': None, 'name': None},
+                'killed': False,
+                'treatments': None,
+                'defaultTreatment': 'off',
+                'baselineTreatment': 'off',
+                'trafficAllocation': 100,
+                'rules': None,
+                'defaultRule': None,
+                'creationTime': None,
+                'lastUpdateTime': None,
+                'lastTrafficReceivedAt': None
+            }
+        assert object_to_stringified_dict(result) == data


### PR DESCRIPTION
`split_definitions.find` method uses the `list` method to get all definitions and then filter by name.
In a workspace with too many splits, this can be a performance issue since several requests are made unnecessarily, and could be affected by rate limits.

This PR adds a new method to get a definition by name directly leveraging a single request to `splits/ws/{workspaceId}/{splitName}/environments/{environmentId}`